### PR TITLE
Updated browser-sync dependency to fix version not found error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt jasmine_node"
   },
   "dependencies": {
-    "browser-sync": "0.7.6"
+    "browser-sync": "0.7.7"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Fixes:

```
npm ERR! Error: version not found: 0.7.6 : browser-sync/0.7.6
npm ERR!     at RegClient.<anonymous> (C:\Users\Enzy\AppData\Roaming\npm\node_modules\npm\node_modules\npm-registry-client\lib\request.js:254:14)
npm ERR!     at Request._callback (C:\Users\Enzy\AppData\Roaming\npm\node_modules\npm\node_modules\npm-registry-client\lib\request.js:192:65)
npm ERR!     at Request.self.callback (C:\Users\Enzy\AppData\Roaming\npm\node_modules\npm\node_modules\request\request.js:123:22)
npm ERR!     at Request.EventEmitter.emit (events.js:98:17)
npm ERR!     at Request.<anonymous> (C:\Users\Enzy\AppData\Roaming\npm\node_modules\npm\node_modules\request\request.js:893:14)
npm ERR!     at Request.EventEmitter.emit (events.js:117:20)
npm ERR!     at IncomingMessage.<anonymous> (C:\Users\Enzy\AppData\Roaming\npm\node_modules\npm\node_modules\request\request.js:844:12)
npm ERR!     at IncomingMessage.EventEmitter.emit (events.js:117:20)
npm ERR!     at _stream_readable.js:920:16
npm ERR!     at process._tickCallback (node.js:415:13)
npm ERR! If you need help, you may report this *entire* log,
npm ERR! including the npm and node versions, at:
npm ERR!     <http://github.com/npm/npm/issues>

npm ERR! System Windows_NT 6.2.9200
npm ERR! command "node" "C:\\Users\\Enzy\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js" "install"
npm ERR! cwd C:\Work\Clevis\zeleni-misasuchardova
npm ERR! node -v v0.10.26
npm ERR! npm -v 1.4.6
```
