### PR TITLE
Add a flag or option "keepalive"

### DIFF
--- a/tasks/browser-sync.js
+++ b/tasks/browser-sync.js
@@ -18,6 +18,8 @@ module.exports = function (grunt) {
 
         var patterns;
 
+        var keepAlive = this.flags.keepalive || options.keepalive;
+
         if (this.data && this.data.bsFiles && this.data.bsFiles.src) {
             patterns = this.data.bsFiles.src;
             if (typeof patterns === "string") {
@@ -45,8 +47,8 @@ module.exports = function (grunt) {
         browserSync.init(patterns, options);
 
         //noinspection JSUnresolvedVariable
-        if (options.watchTask || options.watchtask || options.background) {
-            done(); // Allow Watch task to run after
+        if (options.watchTask || options.watchtask || options.background || !keepAlive) {
+            done(); // Allow Watch or other task to run after
         }
     });
 };


### PR DESCRIPTION
Hi there. I'm trying to implement this plugin for yeoman generators and found a small problem. Usually grunt tasks will die after grunt finishes running. Plugins like [grunt-contrib-connect](https://github.com/gruntjs/grunt-contrib-connect#connect-task) uses a flag or option to indicate whether you want to keep it alive. Thus this PR. But this might break the previous tasks. Another option is if `keepalive=false` does not present keep it alive by default. let me know what you think. Thanks for this great plugin.

BREAKING CHANGE: the server will only runs as long as grunt is running. Once grunts tasks have completed, the web server stops. This behavior can be changed with the keepalive option, and can be enabled ad-hoc by running the task like grunt browserSync:keepalive