### PR TITLE
Enforce other tasks to ran after init

### DIFF
--- a/tasks/browser-sync.js
+++ b/tasks/browser-sync.js
@@ -46,8 +46,9 @@ module.exports = function (grunt) {
 
         //noinspection JSUnresolvedVariable
         if (options.watchTask || options.watchtask || options.background) {
+            
             // Wait until browserSync fully initializes
-            browserSync.emitter.on('init', function() {
+            browserSync.emitter.on('service:running', function() {
                 done(); // Allow Watch task to run after
             });
         }


### PR DESCRIPTION
The Browser Sync task frees it's "thread" right after initializing itself. As the init method is asynchronous, other tasks may run before Browser Sync finishes it's initialization, specially when using `proxy`, `server` or not defining `online`. This can lead to problems when someone needs to have Browser Sync working before running other tasks.

This addresses #85.

This implementation assume every user wants to wait until a Grunt task is completed to run another task. This is the default behavior of most of the Grunt tasks, as Grunt do not easily works well with callbacks nor promises.

Should we create an option (maybe `async`) that defaults to `true` (how Browser Sync works right now)? `false` would make the task behave like a synchronous one (what my implementation does).
