### PR TITLE
Log fatal fail to console when BrowserSync has a error

### DIFF
--- a/tasks/browser-sync.js
+++ b/tasks/browser-sync.js
@@ -47,6 +47,7 @@ module.exports = function (grunt) {
         bs.init(patterns || [], options, function (err) {
             if (err) {
                 done(err);
+                grunt.fail.fatal(err);
                 return;
             }
 


### PR DESCRIPTION
It is hard to understand what options are causing the problems when Grunt task is quiet, so I added a `grunt.fail.fatal` call with `err` before return.
