### PR TITLE
feat: add (optional) timeout argument to bsNotify task

### DIFF
--- a/tasks/browser-sync.js
+++ b/tasks/browser-sync.js
@@ -67,7 +67,7 @@ module.exports = function (grunt) {
 
     grunt.registerMultiTask("bsNotify", function () {
         if (bs && bs.active) {
-            bs.notify(this.data.notify);
+            bs.notify(this.data.notify, this.data.timeout);
         }
     });
 };


### PR DESCRIPTION
This simple commit adds the ability to set a timeout via the bsNotify task configuration.

For example, consider the following setup:

```javascript
module.exports = function(grunt) {
  grunt.initConfig({
    bsNotify: {
      karma: {
        notify: 'Tests passed',
        timeout: 5000
      }
    },
    watch: {
      options: {
        spawn: false
      },
      tests: {
        files: ['src/*.spec.js'],
        tasks: ['bsNotify:karma']
      }
    }
  });
};
```

This will allow the notification to be in the browser sync window for a bit more of a reasonable timespan. Note, that a truth-y trust is currently the condition in the core browser-sync code, so if `this.data.timeout` is undefined, the condition will evaluate to false and use the established 2000 ms default.