### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ This plugin requires Grunt `~0.4.1`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins.
 
-##About
+## About
 
 For a full list of features, please visit [https://github.com/shakyShane/browser-sync](https://github.com/shakyShane/browser-sync)
 
 
-##Install
+## Install
 
 ```shell
 npm install grunt-browser-sync --save-dev
@@ -26,10 +26,10 @@ Once the plugin has been installed, it may be enabled inside your Gruntfile with
 grunt.loadNpmTasks('grunt-browser-sync');
 ```
 
-##Usage
+## Usage
 Please see the [Grunt JS](http://www.browsersync.io/docs/grunt/) section of the Official [BrowserSync Documentation](http://www.browsersync.io/docs/).
 
-##Support
+## Support
 If you've found Browser-sync useful and would like to contribute to its continued development & support, please feel free to send a donation of any size - it would be greatly appreciated!
 
 [![Support via Gittip](https://rawgithub.com/chris---/Donation-Badges/master/gittip.jpeg)](https://www.gittip.com/shakyshane)

--- a/readme.old.md
+++ b/readme.old.md
@@ -9,12 +9,12 @@ This plugin requires Grunt `~0.4.1`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins.
 
-##About
+## About
 
 For a full list of features, please visit [https://github.com/shakyShane/browser-sync](https://github.com/shakyShane/browser-sync)
 
 
-##Install
+## Install
 
 ```shell
 npm install grunt-browser-sync --save-dev
@@ -26,7 +26,7 @@ Once the plugin has been installed, it may be enabled inside your Gruntfile with
 grunt.loadNpmTasks('grunt-browser-sync');
 ```
 
-##Config
+## Config
 Here's an example of the simplest configuration possible. This will give you a HTML snippet to paste into the footer of your website to enable browser-sync.
 
 ```
@@ -39,7 +39,7 @@ browserSync: {
 
 Here's a [full list of available options.](https://github.com/shakyShane/browser-sync/wiki/options)
 
-###Screencasts ( < 3 min each )
+### Screencasts ( < 3 min each )
 
 
 Browser-sync + Jekyll + Sass
@@ -55,7 +55,7 @@ Browser-sync + CabinJS
 
 Want any more? Something specific? ask me nicely [@shaneOsbourne](http://www.twitter.com/shaneOsbourne)
 
-##Important: Using browser-sync + grunt watch
+## Important: Using browser-sync + grunt watch
 If you are using both of these, scroll down to the **watchTask** option below to see how to config them to be used together!
 
 ## + static file server
@@ -94,18 +94,18 @@ browserSync: {
 Using the **proxy** option will give you an IP address that you can access from any device/computer on your network automagically.
 
 
-##bsFiles - explained (version > 0.4.3 required)
+## bsFiles - explained (version > 0.4.3 required)
 
 You may be wondering why browser-sync accepts a `bsFiles` property (see the examples below)… It's because browser-sync has it's own file-watching functionality built in & you can skip grunt doing file look-ups by changing the regular **files** property to **bsFiles**. (this also allows browser-sync to respond to newly added files, like grunt-contrib-watch does)
 
-##Run
+## Run
 
 `grunt browserSync`
 
 When you've used one of the configs from above, run this command from the terminal and you'll be good to go (if you are using the built-in server). If you are not using the built in server or the proxy, (because your site is on PHP or something else), just grab the HTML snippet from the command line and paste it into your site just before the closing `</body` tag
 
 
-##Options
+## Options
 
 Here's another example config with options, each will be explained after.
 
@@ -126,7 +126,7 @@ browserSync: {
     }
 },
 ```
-###watchTask (default: *false*)
+### watchTask (default: *false*)
 Browser Sync is not a replacement for regular `watch` tasks (such as compiling SASS, LESS etc), they are designed to be used together. If you intend to do this, set this option to true and be sure to call the `watch` task AFTER `browserSync`. For example, to compile SASS and then inject the CSS into all open browsers (without a page refresh), your config for all three tasks might look something like this:
 
 
@@ -169,7 +169,7 @@ module.exports = function (grunt) {
 };
 ```
 
-###host (default: *null*)
+### host (default: *null*)
 Browser Sync will attempt to figure out the correct external IP to use on your network. Occasionally though, it may select
 one that cannot be accessed on any other devices (just the machine you are developing on). If this happens, and you know exactly
 which IP to use on your network, you can plug it in here.
@@ -193,7 +193,7 @@ grunt.initConfig({
 > A quick word on hosts...
 The power of Browser Sync comes when you have multiple devices/browsers connected. To do this, you use your networks IP instead of `localhost`. For example, you may have a php/node/mamp server running at `localhost:8000`. Swap out the localhost part for something like `192.168.0.1` (find yours by running `ifconfig` on Mac, `ipconfig` on Windows) and you can connect to **192.168.0.1:8000**. Now, with Browser Sync running, you can have as many browsers/devices connected and they will all live-update when you change a file.
 
-###ports (default: null)
+### ports (default: null)
 Browser-sync will detect up to 3 available ports to use within a fixed range. You can override this if you need to by supplying min & max values.
 
 ```js
@@ -214,7 +214,7 @@ grunt.initConfig({
 });
 ```
 
-###ghostMode (default: *true*)
+### ghostMode (default: *true*)
 There are currently 4 options for **ghostMode** `clicks`, `scroll`, `links` & `forms`
 - Clicks. *alpha* All clicks will be mirrored across devices.
 - Scroll. Enable this and your connected browsers will attempt to keep in sync
@@ -243,7 +243,7 @@ grunt.initConfig({
 });
 
 ```
-###server (default: *false*)
+### server (default: *false*)
 Using the `server` option negates the need for the HTML snippet as it will be injected automatically (no browser plugins needed!). Just provide the base directory where you want to serve your files from and you'll be good to go!.
 
 ```js
@@ -264,7 +264,7 @@ grunt.initConfig({
 });
 
 ```
-###server.index (default: *false*)
+### server.index (default: *false*)
 If you are using the server feature & for some reason your index page is NOT 'index.html', you can specify which file to load instead.
 ```js
 grunt.initConfig({
@@ -285,7 +285,7 @@ grunt.initConfig({
 });
 ```
 
-##Live Reload
+## Live Reload
 Browser Sync injects CSS into all connected browsers without reloading the page & it even works on VMs running IE 7 & 8! But that's not all it does. It can also live-inject jpg & png files too, as well as perform a hard refresh for JS, PHP, HTML files etc. For example:
 
 ```js
@@ -308,7 +308,7 @@ grunt.initConfig({
 ```
 
 
-##Support
+## Support
 If you've found Browser-sync useful and would like to contribute to its continued development & support, please feel free to send a donation of any size - it would be greatly appreciated!
 
 [![Support via Gittip](https://rawgithub.com/chris---/Donation-Badges/master/gittip.jpeg)](https://www.gittip.com/shakyshane)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
