### PR TITLE
Add support of callback for init method

### DIFF
--- a/tasks/browser-sync.js
+++ b/tasks/browser-sync.js
@@ -46,7 +46,7 @@ module.exports = function (grunt) {
 
         bs.init(patterns || [], options, function (err) {
             if (typeof options.cb === 'function') {
-              options.cb(err, bs);
+              options.cb(err, bs, done);
             }
 
             if (err) {

--- a/tasks/browser-sync.js
+++ b/tasks/browser-sync.js
@@ -50,6 +50,10 @@ module.exports = function (grunt) {
                 return;
             }
 
+            if (typeof options.cb === 'function') {
+              options.cb(err, bs)
+            }
+
             if (options.watchTask   ||
                 options.watchtask   ||
                 options.background  ||

--- a/tasks/browser-sync.js
+++ b/tasks/browser-sync.js
@@ -51,7 +51,7 @@ module.exports = function (grunt) {
             }
 
             if (typeof options.cb === 'function') {
-              options.cb(err, bs)
+              options.cb(err, bs);
             }
 
             if (options.watchTask   ||

--- a/tasks/browser-sync.js
+++ b/tasks/browser-sync.js
@@ -45,13 +45,13 @@ module.exports = function (grunt) {
         }
 
         bs.init(patterns || [], options, function (err) {
+            if (typeof options.cb === 'function') {
+              options.cb(err, bs);
+            }
+
             if (err) {
                 done(err);
                 return;
-            }
-
-            if (typeof options.cb === 'function') {
-              options.cb(err, bs);
             }
 
             if (options.watchTask   ||


### PR DESCRIPTION
Adds ability to pass callback from Grunt task to `bs.init()`, which will be executed _after_ bs had initialized, thus allowing to achieve same functionality as [docs](https://browsersync.io/docs/api#api-init) describing.

For some tasks this is crucial. For instance, it's impossible to implement this [example](https://github.com/BrowserSync/browser-sync/blob/master/examples/404.js) without access to callback (maybe there is a method to do same with bare middleware, but I didn't fint how).

With this PR it can be done by writing following Grunt task options:

```js
options: {
  cb: (err, bs) => bs.addMiddleware('*', (req, res) => {
    res.writeHead(302, { 'location': '404.html' })
    res.end('Redirecting!')
}
```